### PR TITLE
fix:react version & explicit pinning

### DIFF
--- a/frameworks/react/package.json
+++ b/frameworks/react/package.json
@@ -58,8 +58,8 @@
     "@arweave-wallet-kit/core": "workspace:*",
     "@arweave-wallet-kit/styles": "workspace:*",
     "arweave": ">= 1.12.2 < 2",
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/frameworks/react/package.json
+++ b/frameworks/react/package.json
@@ -45,7 +45,7 @@
     "arweave": "^1.15.5",
     "babel-loader": "^8.3.0",
     "prettier": "^2.8.2",
-    "react": "^0.1.0",
+    "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rollup-plugin-preserve-directives": "^0.2.0",
     "typescript": "^4.9.3",
@@ -58,8 +58,8 @@
     "@arweave-wallet-kit/core": "workspace:*",
     "@arweave-wallet-kit/styles": "workspace:*",
     "arweave": ">= 1.12.2 < 2",
-    "react": "^0.1.0",
-    "react-dom": "^16.8.0 || 17.x || 18.x"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
# Fix React Version and Dependency Organization

## Changes
- Fixed incorrect React version in devDependencies from `^0.1.0` to `^18.2.0`
- Updated React peer dependency to use proper semver ranges (`^16.8.0 || ^17.0.0 || ^18.0.0`)
- Updated React DOM peer dependency to match React version ranges
- Maintained `@arweave-wallet-kit/core` in devDependencies (not dependencies) since it's a peer dependency
- Kept workspace dependencies flexible for local development

## Why
The previous package.json had an invalid React version (`^0.1.0`) which could cause installation issues. This PR fixes that and ensures proper version ranges for React compatibility, starting from v16.8 (when hooks were introduced) through the latest v19.