### PR TITLE
fix: support for react 19

### DIFF
--- a/frameworks/react/package.json
+++ b/frameworks/react/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@callstack/react-theme-provider": "^3.0.8",
+    "@emotion/is-prop-valid": "^1.3.1",
     "@iconicicons/react": "^1.5.1",
     "@linaria/core": "^6.1.0",
     "@linaria/react": "^6.1.0",

--- a/frameworks/react/vite.config.ts
+++ b/frameworks/react/vite.config.ts
@@ -31,7 +31,12 @@ export default defineConfig({
       fileName: (format) => `index.${format}.js`,
     },
     rollupOptions: {
-      external: ["react", "react-dom", /^@arweave-wallet-kit\/styles\/.*/],
+      external: [
+        "react",
+        "react-dom",
+        /^@arweave-wallet-kit\/styles\/.*/,
+        "react/jsx-runtime",
+      ],
       output: {
         plugins: [
           /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,9 @@ importers:
       '@callstack/react-theme-provider':
         specifier: ^3.0.8
         version: 3.0.9(react@18.3.1)
+      '@emotion/is-prop-valid':
+        specifier: ^1.3.1
+        version: 1.3.1
       '@iconicicons/react':
         specifier: ^1.5.1
         version: 1.5.1(react@18.3.1)


### PR DESCRIPTION
## Summary of changes:
Added `react/jsx-runtime` to the external dependencies list in the vite rollup configuration. This ensures the package uses the host application's JSX runtime rather than being bundled with the version specified in its devDependencies.
Have also added `@emotion/is-prop-valid` to `@arweave-wallet-kit/react` as this is required by `framer-motion` and `@linaria/react` when run in a react 19 environment.

Have confirmed compatibility with both react 18 and 19 for both react and next example apps.

Please reach out to [me on telegram](https://t.me/williamkibbler) for any questions.