### PR TITLE
release: support react 19 in react framework

### DIFF
--- a/.changeset/flat-laws-sing.md
+++ b/.changeset/flat-laws-sing.md
@@ -1,0 +1,5 @@
+---
+"@arweave-wallet-kit/react": minor
+---
+
+support react 19

--- a/.changeset/flat-laws-sing.md
+++ b/.changeset/flat-laws-sing.md
@@ -1,5 +1,0 @@
----
-"@arweave-wallet-kit/react": minor
----
-
-support react 19

--- a/examples/next/CHANGELOG.md
+++ b/examples/next/CHANGELOG.md
@@ -1,5 +1,12 @@
 # next
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies [7824f93]
+  - @arweave-wallet-kit/react@0.3.0
+
 ## 0.1.2
 
 ### Patch Changes

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "next",
+  "name": "nextjs",
   "version": "0.1.2",
   "private": true,
   "scripts": {

--- a/examples/react-simple/CHANGELOG.md
+++ b/examples/react-simple/CHANGELOG.md
@@ -1,0 +1,8 @@
+# react-simple
+
+## 0.0.1
+
+### Patch Changes
+
+- Updated dependencies [7824f93]
+  - @arweave-wallet-kit/react@0.3.0

--- a/examples/react-simple/package.json
+++ b/examples/react-simple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-simple",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/react/CHANGELOG.md
+++ b/examples/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # react
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies [7824f93]
+  - @arweave-wallet-kit/react@0.3.0
+
 ## 0.1.1
 
 ### Patch Changes

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react",
+  "name": "reactjs",
   "version": "0.1.1",
   "private": true,
   "type": "module",

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactjs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frameworks/react/CHANGELOG.md
+++ b/frameworks/react/CHANGELOG.md
@@ -1,11 +1,16 @@
 # @arweave-wallet-kit/react
 
+## 0.3.0
+
+### Minor Changes
+
+- 7824f93: support react 19
+
 ## 0.2.0
 
 ### Minor Changes
 
 - d83a63f: update arns and add svgie in react framework
-
 
 ### Patch Changes
 

--- a/frameworks/react/package.json
+++ b/frameworks/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arweave-wallet-kit/react",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "private": false,
   "type": "module",
   "exports": {


### PR DESCRIPTION
- change project name from next -> nextjs and react -> reactjs in examples dir to get around changesets issue

Support react 19
+ @arweave-wallet-kit/react@0.3.0