### PR TITLE
Add Wander Connect Strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ In Arweave Wallet Kit, a _strategy_ is an implementation of an Arweave wallet wi
 The library currently supports the following wallets:
 
 - [Wander.app](https://wander.app)
+- [Wander Connnect](https://wander.app/connect)
 - [Arweave.app](https://arweave.app)
 - [Othent](https://othent.io)
 - General Browser Wallets
@@ -41,6 +42,7 @@ The core and styles package are peer dependencies for the the `react` package.
 Alongside these, the strategies for each wallet have their own dedicated packages as well:
 
 - `@arweave-wallet-kit/wander-strategy`
+- `@arweave-wallet-kit/wander-connect-strategy`
 - `@arweave-wallet-kit/browser-wallet-strategy`
 - `@arweave-wallet-kit/othent-strategy`
 - `@arweave-wallet-kit/webwallet-strategy`
@@ -60,6 +62,7 @@ pnpm add @arweave-wallet-kit/core \
          @arweave-wallet-kit/styles \
          @arweave-wallet-kit/react \
          @arweave-wallet-kit/wander-strategy \
+         @arweave-wallet-kit/wander-connect-strategy \
          @arweave-wallet-kit/webwallet-strategy \
          @arweave-wallet-kit/othent-strategy \
          @arweave-wallet-kit/browser-wallet-strategy
@@ -77,6 +80,7 @@ import App from "./App.tsx";
 import "./index.css";
 import { ArweaveWalletKit } from "@arweave-wallet-kit/react";
 import WanderStrategy from "@arweave-wallet-kit/wander-strategy";
+import WanderConnectStrategy from "@arweave-wallet-kit/wander-connnect-strategy";
 import OthentStrategy from "@arweave-wallet-kit/othent-strategy";
 import BrowserWalletStrategy from "@arweave-wallet-kit/browser-wallet-strategy";
 import WebWalletStrategy from "@arweave-wallet-kit/webwallet-strategy";
@@ -94,6 +98,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
         ensurePermissions: true,
         strategies: [
           new WanderStrategy(),
+          new WanderConnectStrategy(),
           new OthentStrategy(),
           new BrowserWalletStrategy(),
           new WebWalletStrategy(),
@@ -112,6 +117,6 @@ Once the provider is setup, you can either use the Wallet Kit’s functionality 
 
 ## Extending functionality or adding a wallet
 
-If your wallet implements the common `arweaveWallet` API that wallets like `Wander` and `Arweave.app` inject by default, the regular `browser-wallet-strategy` should work out of the box.
+If your wallet implements the common `arweaveWallet` API that wallets like `Wander`, `Wander Connect` and `Arweave.app` inject by default, the regular `browser-wallet-strategy` should work out of the box.
 
 In order to add another wallet that is not in this list, you need to have a package that implements the abstract class [`Strategy.ts`](https://github.com/labscommunity/arweave-wallet-kit-monorepo/blob/main/packages/wallet-kit-core/src/strategy/Strategy.ts) to interface between the kit and the corresponding wallet.

--- a/frameworks/react-legacy/package.json
+++ b/frameworks/react-legacy/package.json
@@ -30,6 +30,7 @@
     "@arweave-wallet-kit/othent-strategy": "workspace:*",
     "@arweave-wallet-kit/react": "workspace:*",
     "@arweave-wallet-kit/styles": "workspace:*",
+    "@arweave-wallet-kit/wander-connect-strategy": "workspace:*",
     "@arweave-wallet-kit/wander-strategy": "workspace:*",
     "@arweave-wallet-kit/webwallet-strategy": "0.0.1-beta.4",
     "@vela-ventures/aosync-strategy": "^1.0.3",

--- a/frameworks/react-legacy/src/awkWrapper.tsx
+++ b/frameworks/react-legacy/src/awkWrapper.tsx
@@ -5,6 +5,7 @@ import { type Config, defaultConfig } from "@arweave-wallet-kit/core/config";
 import { type ThemeConfig } from "@arweave-wallet-kit/core/theme";
 
 import WanderStrategy from "@arweave-wallet-kit/wander-strategy";
+import WanderConnectStrategy from "@arweave-wallet-kit/wander-connect-strategy";
 import WebWalletStrategy from "@arweave-wallet-kit/webwallet-strategy";
 import OthentStrategy from "@arweave-wallet-kit/othent-strategy";
 import BrowserWalletStrategy from "@arweave-wallet-kit/browser-wallet-strategy";
@@ -13,6 +14,7 @@ import BeaconWallet from "@vela-ventures/aosync-strategy";
 // Define the default strategies that will always be used
 const defaultStrategies = [
   new WanderStrategy(),
+  new WanderConnectStrategy(),
   new WebWalletStrategy(),
   new OthentStrategy(),
   new BrowserWalletStrategy(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,7 +114,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.3.4(vite@5.4.14(@types/node@20.17.18)(sass@1.84.0)(terser@5.39.0))
+        version: 4.3.4(vite@5.4.14(@types/node@22.13.2)(sass@1.84.0)(terser@5.39.0))
       eslint:
         specifier: ^9.13.0
         version: 9.20.1
@@ -135,7 +135,7 @@ importers:
         version: 8.24.0(eslint@9.20.1)(typescript@5.6.3)
       vite:
         specifier: ^5.4.10
-        version: 5.4.14(@types/node@20.17.18)(sass@1.84.0)(terser@5.39.0)
+        version: 5.4.14(@types/node@22.13.2)(sass@1.84.0)(terser@5.39.0)
 
   examples/react-simple:
     dependencies:
@@ -172,7 +172,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.1.0(@types/node@20.17.18)(sass@1.84.0)(terser@5.39.0))
+        version: 4.3.4(vite@6.1.0(@types/node@22.13.2)(sass@1.84.0)(terser@5.39.0))
       eslint:
         specifier: ^9.17.0
         version: 9.20.1
@@ -193,7 +193,7 @@ importers:
         version: 8.24.0(eslint@9.20.1)(typescript@5.6.3)
       vite:
         specifier: ^6.0.5
-        version: 6.1.0(@types/node@20.17.18)(sass@1.84.0)(terser@5.39.0)
+        version: 6.1.0(@types/node@22.13.2)(sass@1.84.0)(terser@5.39.0)
 
   examples/react-simple-legacy:
     dependencies:
@@ -218,7 +218,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.1.0(@types/node@20.17.18)(sass@1.84.0)(terser@5.39.0))
+        version: 4.3.4(vite@6.1.0(@types/node@22.13.2)(sass@1.84.0)(terser@5.39.0))
       eslint:
         specifier: ^9.17.0
         version: 9.20.1
@@ -239,13 +239,13 @@ importers:
         version: 8.24.0(eslint@9.20.1)(typescript@5.6.3)
       vite:
         specifier: ^6.0.5
-        version: 6.1.0(@types/node@20.17.18)(sass@1.84.0)(terser@5.39.0)
+        version: 6.1.0(@types/node@22.13.2)(sass@1.84.0)(terser@5.39.0)
 
   frameworks/react:
     dependencies:
       '@arweave-wallet-kit/styles':
-        specifier: workspace:*
-        version: link:../../packages/wallet-kit-styles
+        specifier: ^0.1.1
+        version: 0.1.1
       '@callstack/react-theme-provider':
         specifier: ^3.0.8
         version: 3.0.9(react@18.3.1)
@@ -262,7 +262,7 @@ importers:
         specifier: ^6.1.0
         version: 6.2.1(react@18.3.1)
       '@permaweb/aoconnect':
-        specifier: ^0.0.65
+        specifier: '>= 0.0.65'
         version: 0.0.65
       '@wyw-in-js/babel-preset':
         specifier: ^0.4.1
@@ -275,8 +275,8 @@ importers:
         version: 6.1.0(react@18.3.1)
     devDependencies:
       '@arweave-wallet-kit/core':
-        specifier: workspace:*
-        version: link:../../packages/wallet-kit-core
+        specifier: ^0.1.1
+        version: 0.1.1
       '@babel/preset-env':
         specifier: ^7.26.0
         version: 7.26.8(@babel/core@7.26.8)
@@ -562,6 +562,40 @@ importers:
         specifier: ^3.2.0
         version: 3.9.1(@types/node@20.17.18)(rollup@4.34.6)(typescript@5.6.3)(vite@4.5.9(@types/node@20.17.18)(sass@1.84.0)(terser@5.39.0))
 
+  strategies/wander-connect:
+    dependencies:
+      '@wanderapp/connect':
+        specifier: ^0.1.1
+        version: 0.1.1
+    devDependencies:
+      '@arweave-wallet-kit/browser-wallet-strategy':
+        specifier: workspace:*
+        version: link:../browser-wallet
+      '@arweave-wallet-kit/core':
+        specifier: workspace:*
+        version: link:../../packages/wallet-kit-core
+      '@types/node':
+        specifier: ^20.4.2
+        version: 20.17.18
+      arconnect:
+        specifier: ^1.0.4
+        version: 1.0.4
+      arweave:
+        specifier: ^1.12.2
+        version: 1.15.5
+      prettier:
+        specifier: ^3.0.0
+        version: 3.5.1
+      typescript:
+        specifier: ^5.1.6
+        version: 5.6.3
+      vite:
+        specifier: ^4.4.3
+        version: 4.5.9(@types/node@20.17.18)(sass@1.84.0)(terser@5.39.0)
+      vite-plugin-dts:
+        specifier: ^3.2.0
+        version: 3.9.1(@types/node@20.17.18)(rollup@4.34.6)(typescript@5.6.3)(vite@4.5.9(@types/node@20.17.18)(sass@1.84.0)(terser@5.39.0))
+
 packages:
 
   '@ampproject/remapping@2.3.0':
@@ -570,6 +604,9 @@ packages:
 
   '@arweave-wallet-kit/core@0.1.1':
     resolution: {integrity: sha512-FA7Ync5iZ4Ts0ICqpcrpZ9nLsTWC+qCOQmTHhWSF2qxqZ7f2blhYdXgjCqxMAN32DzEgCRdvdqsiXudRu2yn9g==}
+
+  '@arweave-wallet-kit/styles@0.1.1':
+    resolution: {integrity: sha512-O8kAKaNGhvL6Rs0lnQBhw+1Bm8HVGLSIK5/yb+1RXILnkyGQ6VFuYVV2dL2yNVldiJianEzkjvmEzfotf/g9sw==}
 
   '@arweave-wallet-kit/webwallet-strategy@0.0.1-beta.4':
     resolution: {integrity: sha512-nvKv44IV+yj/wHVthI7sJ64CwKji1VEipu5rAJAfhNZtXX3YfD4+GQkgKghTfXZjwOLVc61u4SkEy8DszvJD+Q==}
@@ -2345,6 +2382,9 @@ packages:
 
   '@vue/shared@3.5.13':
     resolution: {integrity: sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==}
+
+  '@wanderapp/connect@0.1.1':
+    resolution: {integrity: sha512-jIf2IgdUKVQ7kkE5SDah/7kNenwHXd0TiWu+ug6iVKYmjr13OgLhzxim8cK6hCem4UOTne+LE6skh3KfQTYKuQ==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -4170,6 +4210,10 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-deepmerge@7.0.3:
+    resolution: {integrity: sha512-Du/ZW2RfwV/D4cmA5rXafYjBQVuvu4qGiEEla4EmEHVHgRdx68Gftx7i66jn2bzHPwSVZY36Ae6OuDn9el4ZKA==}
+    engines: {node: '>=14.13.1'}
+
   ts-invariant@0.10.3:
     resolution: {integrity: sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==}
     engines: {node: '>=8'}
@@ -4584,6 +4628,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
 
   '@arweave-wallet-kit/core@0.1.1': {}
+
+  '@arweave-wallet-kit/styles@0.1.1': {}
 
   '@arweave-wallet-kit/webwallet-strategy@0.0.1-beta.4(@arweave-wallet-kit/browser-wallet-strategy@strategies+browser-wallet)(@arweave-wallet-kit/core@packages+wallet-kit-core)(arweave-wallet-connector@1.0.2)':
     dependencies:
@@ -6482,25 +6528,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.3.4(vite@5.4.14(@types/node@20.17.18)(sass@1.84.0)(terser@5.39.0))':
+  '@vitejs/plugin-react@4.3.4(vite@5.4.14(@types/node@22.13.2)(sass@1.84.0)(terser@5.39.0))':
     dependencies:
       '@babel/core': 7.26.8
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.8)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.8)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.4.14(@types/node@20.17.18)(sass@1.84.0)(terser@5.39.0)
+      vite: 5.4.14(@types/node@22.13.2)(sass@1.84.0)(terser@5.39.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.3.4(vite@6.1.0(@types/node@20.17.18)(sass@1.84.0)(terser@5.39.0))':
+  '@vitejs/plugin-react@4.3.4(vite@6.1.0(@types/node@22.13.2)(sass@1.84.0)(terser@5.39.0))':
     dependencies:
       '@babel/core': 7.26.8
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.8)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.8)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.1.0(@types/node@20.17.18)(sass@1.84.0)(terser@5.39.0)
+      vite: 6.1.0(@types/node@22.13.2)(sass@1.84.0)(terser@5.39.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6545,6 +6591,10 @@ snapshots:
       typescript: 5.6.3
 
   '@vue/shared@3.5.13': {}
+
+  '@wanderapp/connect@0.1.1':
+    dependencies:
+      ts-deepmerge: 7.0.3
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -8531,6 +8581,8 @@ snapshots:
     dependencies:
       typescript: 5.6.3
 
+  ts-deepmerge@7.0.3: {}
+
   ts-invariant@0.10.3:
     dependencies:
       tslib: 2.8.1
@@ -8706,24 +8758,24 @@ snapshots:
       sass: 1.84.0
       terser: 5.39.0
 
-  vite@5.4.14(@types/node@20.17.18)(sass@1.84.0)(terser@5.39.0):
+  vite@5.4.14(@types/node@22.13.2)(sass@1.84.0)(terser@5.39.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.2
       rollup: 4.34.6
     optionalDependencies:
-      '@types/node': 20.17.18
+      '@types/node': 22.13.2
       fsevents: 2.3.3
       sass: 1.84.0
       terser: 5.39.0
 
-  vite@6.1.0(@types/node@20.17.18)(sass@1.84.0)(terser@5.39.0):
+  vite@6.1.0(@types/node@22.13.2)(sass@1.84.0)(terser@5.39.0):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.5.2
       rollup: 4.34.6
     optionalDependencies:
-      '@types/node': 20.17.18
+      '@types/node': 22.13.2
       fsevents: 2.3.3
       sass: 1.84.0
       terser: 5.39.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -569,7 +569,7 @@ importers:
     dependencies:
       '@wanderapp/connect':
         specifier: ^0.1.3
-        version: 0.1.3
+        version: 0.1.11
     devDependencies:
       '@arweave-wallet-kit/browser-wallet-strategy':
         specifier: workspace:*
@@ -2386,8 +2386,8 @@ packages:
   '@vue/shared@3.5.13':
     resolution: {integrity: sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==}
 
-  '@wanderapp/connect@0.1.3':
-    resolution: {integrity: sha512-oikgdqhGRsZO+zYDiw/wfTYhdlb6JkeTWyCLmTsIapw9wRIuNnAqgL8LNYaxVA2cZ3TwB0D7zLHoj6X/QvV8DQ==}
+  '@wanderapp/connect@0.1.11':
+    resolution: {integrity: sha512-Aeu7Xetav9tuXgoBIbTv7rOdmgu6WO7IsUk07c8apQHbUkCTmDn+1/uS1Hs1yb9+ZDO2i8vmenTPGR2Ioc2E4w==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -6595,7 +6595,7 @@ snapshots:
 
   '@vue/shared@3.5.13': {}
 
-  '@wanderapp/connect@0.1.3':
+  '@wanderapp/connect@0.1.11':
     dependencies:
       ts-deepmerge: 7.0.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,6 +358,9 @@ importers:
       '@arweave-wallet-kit/styles':
         specifier: workspace:*
         version: link:../../packages/wallet-kit-styles
+      '@arweave-wallet-kit/wander-connect-strategy':
+        specifier: workspace:*
+        version: link:../../strategies/wander-connect
       '@arweave-wallet-kit/wander-strategy':
         specifier: workspace:*
         version: link:../../strategies/wander

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -568,7 +568,7 @@ importers:
   strategies/wander-connect:
     dependencies:
       '@wanderapp/connect':
-        specifier: ^0.1.3
+        specifier: ^0.1.11
         version: 0.1.11
     devDependencies:
       '@arweave-wallet-kit/browser-wallet-strategy':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -565,8 +565,8 @@ importers:
   strategies/wander-connect:
     dependencies:
       '@wanderapp/connect':
-        specifier: ^0.1.1
-        version: 0.1.1
+        specifier: ^0.1.3
+        version: 0.1.3
     devDependencies:
       '@arweave-wallet-kit/browser-wallet-strategy':
         specifier: workspace:*
@@ -2383,8 +2383,8 @@ packages:
   '@vue/shared@3.5.13':
     resolution: {integrity: sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==}
 
-  '@wanderapp/connect@0.1.1':
-    resolution: {integrity: sha512-jIf2IgdUKVQ7kkE5SDah/7kNenwHXd0TiWu+ug6iVKYmjr13OgLhzxim8cK6hCem4UOTne+LE6skh3KfQTYKuQ==}
+  '@wanderapp/connect@0.1.3':
+    resolution: {integrity: sha512-oikgdqhGRsZO+zYDiw/wfTYhdlb6JkeTWyCLmTsIapw9wRIuNnAqgL8LNYaxVA2cZ3TwB0D7zLHoj6X/QvV8DQ==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -6592,7 +6592,7 @@ snapshots:
 
   '@vue/shared@3.5.13': {}
 
-  '@wanderapp/connect@0.1.1':
+  '@wanderapp/connect@0.1.3':
     dependencies:
       ts-deepmerge: 7.0.3
 

--- a/strategies/wander-connect/CHANGELOG.md
+++ b/strategies/wander-connect/CHANGELOG.md
@@ -1,0 +1,16 @@
+# @arweave-wallet-kit/wander-strategy
+
+## 0.1.2
+
+### Patch Changes
+
+- d35a093: Update the copy for the description
+
+## 0.1.1
+
+### Patch Changes
+
+- 763263b: update strategies and fix dependencies
+- Updated dependencies [763263b]
+  - @arweave-wallet-kit/browser-wallet-strategy@0.1.1
+  - @arweave-wallet-kit/core@0.1.1

--- a/strategies/wander-connect/LICENSE
+++ b/strategies/wander-connect/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Not Community Labs Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/strategies/wander-connect/README.md
+++ b/strategies/wander-connect/README.md
@@ -1,0 +1,5 @@
+# Wander Strategy
+
+Wander Connect support for the Arweave Wallet Kit
+
+> Warning: This strategy requires [`@arweave-wallet-kit/browser-wallet-strategy`](https://npmjs.com/@arweave-wallet-kit/browser-wallet-strategy) as a peer dependency.

--- a/strategies/wander-connect/README.md
+++ b/strategies/wander-connect/README.md
@@ -1,4 +1,4 @@
-# Wander Strategy
+# Wander Connect Strategy
 
 Wander Connect support for the Arweave Wallet Kit
 

--- a/strategies/wander-connect/package.json
+++ b/strategies/wander-connect/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@arweave-wallet-kit/wander-connect-strategy",
+  "version": "0.1.2",
+  "private": false,
+  "description": "Wander Connect strategy for the Arweave Wallet Kit",
+  "repository": "https://github.com/labscommunity/arweave-wallet-kit-monorepo",
+  "license": "MIT",
+  "author": "Marton Lederer <marton@lederer.hu>",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.es.js",
+      "require": "./dist/index.umd.js"
+    }
+  },
+  "main": "./dist/index.umd.js",
+  "module": "./dist/index.es.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc && vite build",
+    "dev": "vite",
+    "fmt": "prettier . --write"
+  },
+  "devDependencies": {
+    "@arweave-wallet-kit/browser-wallet-strategy": "workspace:*",
+    "@arweave-wallet-kit/core": "workspace:*",
+    "@types/node": "^20.4.2",
+    "arconnect": "^1.0.4",
+    "arweave": "^1.12.2",
+    "prettier": "^3.0.0",
+    "typescript": "^5.1.6",
+    "vite": "^4.4.3",
+    "vite-plugin-dts": "^3.2.0"
+  },
+  "peerDependencies": {
+    "@arweave-wallet-kit/browser-wallet-strategy": "workspace:*",
+    "@arweave-wallet-kit/core": "workspace:*"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@wanderapp/connect": "^0.1.1"
+  }
+}

--- a/strategies/wander-connect/package.json
+++ b/strategies/wander-connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arweave-wallet-kit/wander-connect-strategy",
-  "version": "0.1.2",
+  "version": "0.0.1",
   "private": false,
   "description": "Wander Connect strategy for the Arweave Wallet Kit",
   "repository": "https://github.com/labscommunity/arweave-wallet-kit-monorepo",
@@ -25,6 +25,9 @@
     "dev": "vite",
     "fmt": "prettier . --write"
   },
+  "dependencies": {
+    "@wanderapp/connect": "^0.1.1"
+  },
   "devDependencies": {
     "@arweave-wallet-kit/browser-wallet-strategy": "workspace:*",
     "@arweave-wallet-kit/core": "workspace:*",
@@ -42,8 +45,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "dependencies": {
-    "@wanderapp/connect": "^0.1.1"
   }
 }

--- a/strategies/wander-connect/package.json
+++ b/strategies/wander-connect/package.json
@@ -26,7 +26,7 @@
     "fmt": "prettier . --write"
   },
   "dependencies": {
-    "@wanderapp/connect": "^0.1.1"
+    "@wanderapp/connect": "^0.1.3"
   },
   "devDependencies": {
     "@arweave-wallet-kit/browser-wallet-strategy": "workspace:*",

--- a/strategies/wander-connect/package.json
+++ b/strategies/wander-connect/package.json
@@ -26,7 +26,7 @@
     "fmt": "prettier . --write"
   },
   "dependencies": {
-    "@wanderapp/connect": "^0.1.3"
+    "@wanderapp/connect": "^0.1.11"
   },
   "devDependencies": {
     "@arweave-wallet-kit/browser-wallet-strategy": "workspace:*",

--- a/strategies/wander-connect/src/WanderConnectStrategy.ts
+++ b/strategies/wander-connect/src/WanderConnectStrategy.ts
@@ -1,0 +1,180 @@
+import BrowserWalletStrategy from "@arweave-wallet-kit/browser-wallet-strategy";
+import {
+  AppInfo,
+  GatewayConfig,
+  PermissionType,
+} from "@arweave-wallet-kit/core/wallet";
+import { Strategy } from "@arweave-wallet-kit/core/strategy";
+import { WanderConnect, WanderConnectOptions } from "@wanderapp/connect";
+import Transaction from "arweave/node/lib/transaction";
+import { DataItem } from "arconnect";
+
+const CLIENT_ID = "FREE_TRIAL";
+
+export default class WanderConnectStrategy
+  extends BrowserWalletStrategy
+  implements Strategy
+{
+  public id = "wander-connect";
+  public name = "Wander Connect";
+  public description =
+    "Secure non-custodial Arweave & AO wallet with social logins";
+  //   public theme = "214, 89, 48";
+  public theme = "243, 248, 252";
+  public logo = "9n0Msz31a0NQc6rbCMqunzDQGzz_TuxyeR5MuCrHsPI";
+  public url = "https://www.wander.app/connect";
+
+  private _options;
+  private _isAuthenticated;
+  private _wanderConnect: any;
+  private _arweaveWallet: any;
+
+  constructor(options?: WanderConnectOptions) {
+    super();
+    this._options = options;
+    this._isAuthenticated = false;
+    this._wanderConnect = null;
+    this._arweaveWallet = null;
+  }
+
+  public async isAvailable() {
+    return true;
+  }
+
+  public async connect(
+    permissions: PermissionType[],
+    appInfo?: AppInfo,
+    gateway?: GatewayConfig,
+  ) {
+    // If we're already authenticated, just use the existing wallet connection
+    if (this._isAuthenticated && this._arweaveWallet) {
+      return this._arweaveWallet.connect(permissions, appInfo, gateway);
+    }
+
+    // Create a new authentication promise
+    const authPromise = new Promise<void>((resolve, reject) => {
+      // Only instantiate WanderConnect when connect is called
+      this._wanderConnect = new WanderConnect({
+        clientId: this._options?.clientId || "FREE_TRIAL",
+
+        /** Hide Wander BE Button */
+        hideBE: true,
+
+        /** Hide Wander Connect Button */
+        // TODO: use this option when supported
+        // button: false,
+        button: {
+          position: "bottom-right",
+          //   customStyles: `
+          //         /* Position the button container */
+          //         :host {
+          //             display:none;
+          //         }
+          //         `,
+        },
+        iframe: {
+          /** Choose Modal for Iframe Layout */
+          routeLayout: {
+            auth: "modal",
+            default: "popup",
+            account: "popup",
+            "auth-request": "modal",
+          },
+          /** Bring iframe on top of AWK */
+          customStyles: `
+            .iframe-wrapper, .iframe-wrapper.show {
+                z-index: 999999 !important;
+            }
+
+            .iframe {
+                z-index: 999999 !important;
+            }
+            /*
+            .backdrop, .backdrop.show {
+                display: none !important;
+            }
+            */
+            `,
+        },
+
+        ...this._options,
+        onAuth: (authInfo) => {
+          // Call the original onAuth if provided in options
+          if (this._options?.onAuth) {
+            this._options.onAuth(authInfo);
+          }
+
+          // Handle authentication result
+          if (authInfo.authStatus === "authenticated") {
+            this._isAuthenticated = true;
+            this._arweaveWallet = window.arweaveWallet;
+            resolve();
+          } else {
+            this._isAuthenticated = false;
+            // this._wanderConnect.open();
+            // reject(new Error(`Authentication failed: ${authInfo.authStatus}`));
+          }
+        },
+      });
+      this._wanderConnect.open();
+      // WanderConnect automatically starts authentication when instantiated
+    });
+
+    // Wait for authentication to complete
+    try {
+      await authPromise;
+      // Now call the actual wallet connect method
+      return this._arweaveWallet.connect(permissions, appInfo, gateway);
+    } catch (error) {
+      // Clean up if authentication fails
+      this._wanderConnect = null;
+      this._isAuthenticated = false;
+      throw error;
+    }
+  }
+
+  async _ensureConnected() {
+    if (!this._isAuthenticated || !this._arweaveWallet) {
+      throw new Error("Not connected. Call connect() first.");
+    }
+  }
+
+  public async disconnect() {
+    // await this._ensureConnected();
+    const result = await this._arweaveWallet.disconnect();
+    this._isAuthenticated = false;
+    this._wanderConnect.destroy();
+    this._wanderConnect = null;
+    return result;
+  }
+
+  public async getActiveAddress() {
+    await this._ensureConnected();
+    return this._arweaveWallet.getActiveAddress();
+  }
+
+  public async getPermissions() {
+    if (!this._isAuthenticated || !this._arweaveWallet) return [];
+    return this._arweaveWallet.getPermissions();
+  }
+
+  public async getAllAddresses() {
+    await this._ensureConnected();
+    return this._arweaveWallet.getAllAddresses();
+  }
+
+  public async sign(transaction: Transaction, options?: any) {
+    await this._ensureConnected();
+    return this._arweaveWallet.sign(transaction, options);
+  }
+
+  public async signDataItem(p: DataItem) {
+    await this._ensureConnected();
+    return this._arweaveWallet.signDataItem(p);
+  }
+
+  public async createDataItemSigner() {
+    await this._ensureConnected();
+    return this._arweaveWallet.createDataItemSigner();
+  }
+}

--- a/strategies/wander-connect/src/WanderConnectStrategy.ts
+++ b/strategies/wander-connect/src/WanderConnectStrategy.ts
@@ -19,7 +19,6 @@ export default class WanderConnectStrategy
   public name = "Wander Connect";
   public description =
     "Secure non-custodial Arweave & AO wallet with social logins";
-  //   public theme = "214, 89, 48";
   public theme = "243, 248, 252";
   public logo = "9n0Msz31a0NQc6rbCMqunzDQGzz_TuxyeR5MuCrHsPI";
   public url = "https://www.wander.app/connect";
@@ -46,61 +45,39 @@ export default class WanderConnectStrategy
     appInfo?: AppInfo,
     gateway?: GatewayConfig,
   ) {
-    // If we're already authenticated, just use the existing wallet connection
+    // Use existing connection if user is already authenticated
     if (this._isAuthenticated && this._arweaveWallet) {
       return this._arweaveWallet.connect(permissions, appInfo, gateway);
     }
 
-    // Create a new authentication promise
+    // We need a promise to be fulfilled in order to later call connect
     const authPromise = new Promise<void>((resolve, reject) => {
-      // Only instantiate WanderConnect when connect is called
+      // Only instance WanderConnect when AWK connect is called
       this._wanderConnect = new WanderConnect({
         clientId: this._options?.clientId || "FREE_TRIAL",
-
-        /** Hide Wander BE Button */
-        hideBE: true,
-
-        /** Hide Wander Connect Button */
-        // TODO: use this option when supported
-        // button: false,
-        button: {
-          position: "bottom-right",
-          //   customStyles: `
-          //         /* Position the button container */
-          //         :host {
-          //             display:none;
-          //         }
-          //         `,
-        },
+        hideBE: true, // Hide BE button
+        button: false, // Hide WC buton
         iframe: {
-          /** Choose Modal for Iframe Layout */
           routeLayout: {
-            auth: "modal",
-            default: "popup",
-            account: "popup",
-            "auth-request": "modal",
+            auth: "modal", // Use Modal for auth views
+            default: "modal", // Use Popup for default views
+            account: "modal", // Use Popup for account views
+            "auth-request": "modal", // Use Modal for auth request views
           },
-          /** Bring iframe on top of AWK */
+          // Put iframe on top of AWK
           customStyles: `
             .iframe-wrapper, .iframe-wrapper.show {
                 z-index: 999999 !important;
             }
-
             .iframe {
                 z-index: 999999 !important;
             }
-            /*
-            .backdrop, .backdrop.show {
-                display: none !important;
-            }
-            */
             `,
         },
-
-        ...this._options,
+        ...this._options, // use options passed on Strategy constructor
         onAuth: (authInfo) => {
-          // Call the original onAuth if provided in options
           if (this._options?.onAuth) {
+            // Call original onAuth if provided in options
             this._options.onAuth(authInfo);
           }
 
@@ -108,25 +85,27 @@ export default class WanderConnectStrategy
           if (authInfo.authStatus === "authenticated") {
             this._isAuthenticated = true;
             this._arweaveWallet = window.arweaveWallet;
+            this._wanderConnect.close();
             resolve();
           } else {
             this._isAuthenticated = false;
-            // this._wanderConnect.open();
-            // reject(new Error(`Authentication failed: ${authInfo.authStatus}`));
+            console.log(`[AWK] WC Auth: ${authInfo.authStatus}`);
           }
         },
       });
+      // Open Wander Connect once constructor finishes
       this._wanderConnect.open();
-      // WanderConnect automatically starts authentication when instantiated
     });
 
-    // Wait for authentication to complete
     try {
-      await authPromise;
-      // Now call the actual wallet connect method
+      await authPromise; // Wait for authentication to complete
+
       return this._arweaveWallet.connect(permissions, appInfo, gateway);
     } catch (error) {
       // Clean up if authentication fails
+      try {
+        this._wanderConnect.destroy();
+      } catch {}
       this._wanderConnect = null;
       this._isAuthenticated = false;
       throw error;
@@ -140,7 +119,6 @@ export default class WanderConnectStrategy
   }
 
   public async disconnect() {
-    // await this._ensureConnected();
     const result = await this._arweaveWallet.disconnect();
     this._isAuthenticated = false;
     this._wanderConnect.destroy();

--- a/strategies/wander-connect/src/index.ts
+++ b/strategies/wander-connect/src/index.ts
@@ -1,0 +1,3 @@
+import WanderConnectStrategy from "./WanderConnectStrategy";
+
+export default WanderConnectStrategy;

--- a/strategies/wander-connect/src/vite-env.d.ts
+++ b/strategies/wander-connect/src/vite-env.d.ts
@@ -1,0 +1,14 @@
+import type { ArweaveWalletApi } from "@arweave-wallet-kit/core/wallet";
+
+/// <reference types="vite/client" />
+
+declare global {
+  interface Window {
+    arweaveWallet?: ArweaveWalletApi;
+  }
+
+  interface WindowEventMap {
+    walletSwitch: CustomEvent<{ address: string }>;
+    arweaveWalletLoaded: CustomEvent<{}>;
+  }
+}

--- a/strategies/wander-connect/tsconfig.json
+++ b/strategies/wander-connect/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["ESNext", "dom", "dom.iterable"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src", "node_modules"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/strategies/wander-connect/tsconfig.node.json
+++ b/strategies/wander-connect/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/strategies/wander-connect/vite.config.ts
+++ b/strategies/wander-connect/vite.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "vite";
+import dts from "vite-plugin-dts";
+import path from "node:path";
+
+export default defineConfig({
+  plugins: [
+    dts({ insertTypesEntry: true })
+  ],
+  build: {
+    lib: {
+      entry: path.resolve(__dirname, "src/index.ts"),
+      name: "@arweave-wallet-kit/wander-strategy",
+      formats: ["es", "umd"],
+      fileName: (format) => `index.${format}.js`
+    },
+    rollupOptions: {
+      external: [
+        "@arweave-wallet-kit/browser-wallet-strategy",
+        "@arweave-wallet-kit/core"
+      ]
+    }
+  }
+});


### PR DESCRIPTION
Adds a strategy for Wander Connect

Users can pass the options parameter for Wander Connect's SDK constructor on the WanderConnectStrategy constructor, when creating the instances for each strategy

To simplify the integration, it hides the Wander BE button within Wander Connect because users can add that in AWK as a separate strategy. It also doesn't show the WC button nor the iframe with the wallet dashboard because AWK abstracts the usage of the wallet to avoid dealing with different UIs

It is also included in the AWK React Legacy package by default